### PR TITLE
PEP8, Usage string changes, and a New trove classifier

### DIFF
--- a/ddg.py
+++ b/ddg.py
@@ -11,14 +11,22 @@ def main():
     """Controls the flow of the ddg application"""
 
     'Build the parser and parse the arguments'
-    parser = argparse.ArgumentParser('www.duckduckgo.com zero-click api for your command-line')
+    parser = argparse.ArgumentParser(
+        description='www.duckduckgo.com zero-click api for your command-line'
+    )
     parser.add_argument('query', nargs='*', help='the search query')
-    parser.add_argument('-b', '--bang', action='store_true', help='prefix query with ! and launch the redirect url')
-    parser.add_argument('-d', '--define', action='store_true', help='prefix query with define')
-    parser.add_argument('-j', '--json', action='store_true', help='returns the raw json output')
-    parser.add_argument('-l', '--lucky', action='store_true', help='launch the first url found')
-    parser.add_argument('-s', '--search', action='store_true', help='launch a search on www.duckduckgo.com')
-    parser.add_argument('-u', '--url', action='store_true', help='return the url of the result found')
+    parser.add_argument('-b', '--bang', action='store_true',
+                        help='prefix query with ! and launch the redirect url')
+    parser.add_argument('-d', '--define', action='store_true',
+                        help='prefix query with define')
+    parser.add_argument('-j', '--json', action='store_true',
+                        help='returns the raw json output')
+    parser.add_argument('-l', '--lucky', action='store_true',
+                        help='launch the first url found')
+    parser.add_argument('-s', '--search', action='store_true',
+                        help='launch a search on www.duckduckgo.com')
+    parser.add_argument('-u', '--url', action='store_true',
+                        help='return the url of the result found')
     args = parser.parse_args()
 
     'Get the queries'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 entry_points = {
     'console_scripts': [
         'ddg = ddg:main',
-   ]
+    ]
 }
 
 setup(
@@ -31,6 +31,7 @@ setup(
          'Environment :: Console',
          'License :: OSI Approved :: MIT License',
          'Operating System :: OS Independent',
+         'Programming Language :: Python :: 2.6',
          'Programming Language :: Python :: 2.7',
          'Topic :: Internet :: WWW/HTTP',
          'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
The machine I've tested this on has python 2.6 and I can confirm that this
works perfectly well on 2.6 so I added it as a classifier.

The usage string was being set as the description accidentally. By specifying
what we want the description to be, the usage defaults to what it should be
and `ddg -h` will be more useful.

I made some changes only to confirm with PEP8. Others (mostly line lenght
issues) are up to @justinls to fix if he so desires.
