### PR TITLE
Specify python2 explicitly

### DIFF
--- a/ddg.py
+++ b/ddg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """www.duckduckgo.com zero-click api for your command-line"""
 
 import sys


### PR DESCRIPTION
Use python2 instead of python as per [PEP 394](http://legacy.python.org/dev/peps/pep-0394/).
